### PR TITLE
fix(core): Add more currency symbols for JPY

### DIFF
--- a/src/core/currencies.ts
+++ b/src/core/currencies.ts
@@ -19,7 +19,7 @@ export const currencies = [
   {
     code: 'JPY',
     symbol: '¥',
-    symbolPatterns: ['¥', '円'],
+    symbolPatterns: ['¥', '￥', '円'],
   },
 ] as const;
 

--- a/src/core/extract-money-components.test.ts
+++ b/src/core/extract-money-components.test.ts
@@ -1,6 +1,44 @@
 import { describe, expect, test } from 'vitest';
 import { extractMoneyComponents } from './extract-money-components';
 
+test('only amount', async () => {
+  const actual = extractMoneyComponents('100');
+  expect(actual).toEqual({
+    amount: 100,
+    symbol: undefined,
+  });
+});
+
+test('only symbol', async () => {
+  const actual = extractMoneyComponents('$');
+  expect(actual).toEqual({
+    amount: undefined,
+    symbol: undefined,
+  });
+});
+
+test('comma separator', async () => {
+  const actual = extractMoneyComponents('$1,114,114.25');
+  expect(actual).toEqual({
+    amount: 1114114.25,
+    symbol: '$',
+  });
+});
+
+test('space between currency and amount', async () => {
+  const preSymbol = extractMoneyComponents('$ 100');
+  expect(preSymbol).toEqual({
+    amount: 100,
+    symbol: '$',
+  });
+
+  const postSymbol = extractMoneyComponents('100,000 円');
+  expect(postSymbol).toEqual({
+    amount: 100000,
+    symbol: '円',
+  });
+});
+
 describe('USD', () => {
   test('$', async () => {
     const actual = extractMoneyComponents('$8.25');
@@ -22,18 +60,25 @@ describe('EUR', () => {
 });
 
 describe('JPY', () => {
-  test('円', async () => {
-    const actual = extractMoneyComponents('1200円');
-    expect(actual).toEqual({
-      amount: 1200,
-      symbol: '円',
-    });
-  });
   test('¥', async () => {
     const actual = extractMoneyComponents('¥1200');
     expect(actual).toEqual({
       amount: 1200,
       symbol: '¥',
+    });
+  });
+  test('￥', async () => {
+    const actual = extractMoneyComponents('￥223');
+    expect(actual).toEqual({
+      amount: 223,
+      symbol: '￥',
+    });
+  });
+  test('円', async () => {
+    const actual = extractMoneyComponents('1200円');
+    expect(actual).toEqual({
+      amount: 1200,
+      symbol: '円',
     });
   });
 });

--- a/src/core/extract-money-components.ts
+++ b/src/core/extract-money-components.ts
@@ -9,16 +9,37 @@ export function extractMoneyComponents(str: string) {
 
   const regex = createRegExp(
     maybe(anyOf(...symbolPatterns).groupedAs('symbolPrefix')),
-    oneOrMore(digit)
+    maybe(' '),
+    oneOrMore(anyOf(digit, ','))
       .and(maybe('.', oneOrMore(digit)))
       .groupedAs('amount'),
+    maybe(' '),
     maybe(anyOf(...symbolPatterns).groupedAs('symbolPostfix'))
   );
 
   const match = str.match(regex);
+  if (!match) {
+    return {
+      symbol: undefined,
+      amount: undefined,
+    };
+  }
+
+  const symbol = match.groups.symbolPrefix || match.groups.symbolPostfix;
+
+  const amount =
+    match.groups.amount !== undefined
+      ? sanitizeAmount(match.groups.amount)
+      : undefined;
 
   return {
-    symbol: match?.groups.symbolPrefix || match?.groups.symbolPostfix,
-    amount: match?.groups.amount ? Number(match.groups.amount) : undefined,
+    symbol,
+    amount,
   };
+}
+
+function sanitizeAmount(strAmount: string): number {
+  const strResult = strAmount.replaceAll(',', '');
+  const numResult = Number(strResult);
+  return numResult;
 }


### PR DESCRIPTION
closes https://github.com/bisquit/chrome-currency-translate/issues/1
closes https://github.com/bisquit/chrome-currency-translate/issues/2